### PR TITLE
Add the "phab" binary to composer.json explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
             "email": "stephan@factorial.io"
         }
     ],
+    "bin": [
+        "bin/phab"
+    ],
     "scripts": {
         "auto-scripts": {
 


### PR DESCRIPTION
This make Composer install the binary to `vendor/bin` if phabalicious is not installed via the phar